### PR TITLE
Add repository for latest Commons Imaging SNAPSHOT to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,20 @@
     <name>qart4j</name>
     <url>http://maven.apache.org</url>
 
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
For those who didn't have the Apache Commons Imaging cached local with Maven, the first time to run

```
mvn compile assembly:single
```

will get error:

> [ERROR] Failed to execute goal on project qart4j: Could not resolve dependencies for project free6om.research.qart4j:qart4j:jar:1.0-SNAPSHOT: Could not find artifact org.apache.commons:commons-imaging:jar:1.0-SNAPSHOT -> [Help 1]
> [ERROR] 
> [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
> [ERROR] Re-run Maven using the -X switch to enable full debug logging.
> [ERROR] 
> [ERROR] For more information about the errors and possible solutions, please read the following articles:
> [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException

As described on [Commons Imaging Page](https://commons.apache.org/proper/commons-imaging/):

> For pulling the latest snapshot via maven you need to add the Apache snapshot repository to your pom.xml:
> 
> ```
> <repository>
>   <id>apache.snapshots</id>
>   <name>Apache Development Snapshot Repository</name>
>   <url>https://repository.apache.org/content/repositories/snapshots/</url>
>   <releases>
>     <enabled>false</enabled>
>   </releases>
>   <snapshots>
>     <enabled>true</enabled>
>   </snapshots>
> </repository>  
> ```
