### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##QArt4J##
+## QArt4J ##
 A QR code generator which gives ASCII Art output image.  
 A java version of [QArt](http://research.swtch.com/qart) with enhancement.  
 All credit goes to Russ Cox.
@@ -6,7 +6,7 @@ All credit goes to Russ Cox.
 Sample output:  
 ![Sample Output](sample-output.png)
 
-##How to generate a runnable jar##
+## How to generate a runnable jar ##
 QArt4j is a maven project, run the following command to get a ruunable jar:
 
 ```Bash
@@ -15,7 +15,7 @@ mvn compile assembly:single
 
 This will generate a runnable jar under `target/` directory.
 
-##How to run it##
+## How to run it ##
 QArt4j can run with many parameters, `java -jar qart4j.jar --help` will show all the parameters.
 The parameters which give the sample output are:
 ```Bash
@@ -29,8 +29,8 @@ java -jar qart4j.jar \
 --cw EFFFFFFF
 ```
 
-##Known issues##
+## Known issues ##
 1. JPEG now works, thanks to [Abhinash Khanal](https://github.com/khanal-abhi).
 
-##License##
+## License ##
 [GPLv3](LICENSE.txt)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
